### PR TITLE
feat(chart): nuevo componente de gráfico circular con chips navegables

### DIFF
--- a/src/components/layout/SectionChart.tsx
+++ b/src/components/layout/SectionChart.tsx
@@ -1,178 +1,44 @@
-import { memo, useMemo, useState, useCallback } from "react";
+import { useSettings } from "@/hooks";
+import { memo, useMemo } from "react";
 import { OptimizedImageDisplay } from "../ui/optimized-image-display";
-import { IItemsSectionCards } from "@/types/settings";
-import { useSettings } from "@/hooks/useSettings";
-import { Pie, PieChart, ResponsiveContainer } from "recharts";
-import { Separator } from "../ui/separator";
-import greenPower from "@/assets/svg/green-powersvg.svg";
-
-type DataItem = {
-  name: string;
-  icon: string;
-  color: string;
-  hoverColor: string;
-  value: number;
-  fill?: string;
-};
-
-interface PieLabelProps {
-  cx: number;
-  cy: number;
-  midAngle: number;
-  innerRadius: number;
-  outerRadius: number;
-  payload: DataItem;
-}
-
-const RADIAN = Math.PI / 180;
+import { Chart } from "../ui/chart";
+import { IPaccet } from "@/types/settings";
 
 interface SectionChartProps {
     idSection?: number | string;
-    id?: number | string;
-    subsections?: Array<IItemsSectionCards>;
-    section?: string;
+    withIcon?: boolean;
     title_1?: string;
+    dataSection?: IPaccet[];
     title_2?: string;
     title_3?: string;
-    boton_texto?: string;
-    button_text?: string;
-    button_action_url?: string;
-    button1_action_url?: string;
-    button_text1?: string;
-    button2_action_url?: string;
-    button_text2?: string;
     withBackground?: boolean;
-    withIcon?: boolean;
-    withSubsections?: boolean;
-    sectionClassName?: string;
 }
 
-const SectionChartComponent = ({ id, withIcon = false, idSection = 'section-chart', sectionClassName = '', title_1 = '', title_2 = '', title_3 = '' }: SectionChartProps) => {
-  const { siteSettings } = useSettings();
-  const data = useMemo<DataItem[]>(() => ([
-      { name: 'Eje 3', icon: greenPower, color: '#D0B787', hoverColor: '#77B82E', value: 20 },
-      { name: 'Eje 2', icon: greenPower, color: '#8689A1', hoverColor: '#77B82E', value: 20 },
-      { name: 'Eje 1', icon: greenPower, color: '#D0B787', hoverColor: '#77B82E', value: 20 },
-      { name: 'Eje 7', icon: greenPower, color: '#D0B787', hoverColor: '#77B82E', value: 20 },
-      { name: 'Eje 6', icon: greenPower, color: '#8689A1', hoverColor: '#77B82E', value: 20 },
-      { name: 'Eje 5', icon: greenPower, color: '#D0B787', hoverColor: '#77B82E', value: 20 },
-      { name: 'Eje 4', icon: greenPower, color: '#8689A1', hoverColor: '#77B82E', value: 20 },
-  ]), []);
-
-  const [hoveredIndex, setHoveredIndex] = useState<number | null>(null);
-  const [selectedIndex, setSelectedIndex] = useState<number | null>(2);
-
-  const chartData = useMemo(() => {
-    return data.map((item, index) => ({
-      ...item,
-      fill:
-        index === selectedIndex || index === hoveredIndex
-          ? item.hoverColor
-          : item.color,
-    }));
-  }, [data, hoveredIndex, selectedIndex]);
-
-  const handleMouseEnter = useCallback((_: unknown, index: number) => {
-    setHoveredIndex(index);
-  }, []);
-
-  const handleMouseLeave = useCallback(() => {
-    setHoveredIndex(null);
-  }, []);
-
-  const handleClick = useCallback((_: unknown, index: number) => {
-    console.log('index', index);
-    setSelectedIndex(index);
-  }, []);
-
-  const renderSliceLabel = useCallback((props: PieLabelProps) => {
-    const { cx, cy, midAngle, innerRadius, outerRadius, payload } = props;
-    const radius = innerRadius + (outerRadius - innerRadius) * 0.4;
-    const x = cx + radius * Math.cos(-midAngle * RADIAN);
-    const y = cy + radius * Math.sin(-midAngle * RADIAN);
-    const rotation = -midAngle + 90;
-    return (
-      <g transform={`translate(${x},${y}) rotate(${rotation})`} pointerEvents="none" textAnchor="middle">
-        <text dy="12" fill="#FFFFFF" fontSize="12" fontWeight={600}>
-          {payload.name}
-        </text>
-        <image href={payload.icon} width="25" height="25" x={-11} y={-28} />
-      </g>
-    );
-  }, []);
-
+const SectionChartComponent = ({ idSection, withIcon, title_1, dataSection, title_2, title_3, withBackground = false }: SectionChartProps) => {
+    const { siteSettings } = useSettings();
+    const sectionClassName = useMemo(() => {
+        return `${withBackground ? 'bg-gray-100' : ''}`;
+    }, [withBackground]);
   return (
     <section id={idSection?.toString()} className={sectionClassName}>
-        {withIcon && (
+      {withIcon && (
         <div className="flex flex-row gap-4 justify-center items-center pt-8">
             <OptimizedImageDisplay imagePath={siteSettings?.icon1} alt={title_1} className="w-20 h-20" />
         </div>
-        )}
-        <div className="container mx-auto px-4 text-center py-16 md:py-24">
-            <div className="text-center mb-8">
-                <h2 className="text-4xl md:text-5xl font-bold text-title mb-4">{title_1}</h2>
-            </div>
-
-            <div className="mb-5">
-                {title_2 && <p className="text-xl text-subtitle max-w-3xl mx-auto mb-4">{title_2}</p>}
-                {title_3 && <p className="text-lg text-paragraph max-w-4xl mx-auto">{title_3}</p>}
-            </div>
-
-
-            <div id={`section-content-${id}`} className="flex flex-col lg:flex-row justify-center  items-center gap-8 max-w-6xl mx-auto mt-12">
-                <div className="flex flex-col items-center gap-4 flex-shrink-0">
-                    <div className="relative w-[320px] h-[320px] sm:w-[360px] sm:h-[360px]">
-                        <ResponsiveContainer width="100%" height="100%">
-                            <PieChart>
-                                <Pie
-                                    data={chartData}
-                                    dataKey="value"
-                                    nameKey="name"
-                                    cx="50%"
-                                    cy="50%"
-                                    innerRadius={85}
-                                    outerRadius={150}
-                                    stroke="#ffffff"
-                                    strokeWidth={1}
-                                    isAnimationActive={false}
-                                    labelLine={false}
-                                    label={renderSliceLabel}
-                                    onMouseEnter={handleMouseEnter}
-                                    onMouseLeave={handleMouseLeave}
-                                    onClick={handleClick}
-                                />
-                            </PieChart>
-                        </ResponsiveContainer>
-                        <div className="absolute inset-0 flex items-center justify-center pointer-events-none">
-                            <p className="text-center font-bold text-[#F7931E] leading-6 w-44 sm:w-52">
-                                Da click en
-                                <br />
-                                el eje que
-                                <br />
-                                quieres consultar
-                            </p>
-                        </div>
-                    </div>
-                </div>
-                {typeof selectedIndex === 'number' && (
-                    <div className="flex flex-col justify-start items-start gap-6 text-left flex-1 max-w-2xl">
-                        <h3 className="text-2xl font-bold text-[#572772] max-w-[705px] mx-auto leading-8" style={{ fontFamily: 'Poppins' }}>
-                            {data[selectedIndex].name}
-                        </h3>
-                        <h4 className="text-xl font-bold text-[#572772] max-w-[705px] mx-auto leading-8" style={{ fontFamily: 'Poppins' }}>
-                            Regulación, control y reducción como criterios de mitigación de emisiones de gases y compuestos de efecto invernadero en el Estado de Tlaxcala
-                        </h4>
-                        <Separator />
-                        <p className="font-light text-base leading-[29px] text-paragraph whitespace-pre-line">
-                            Fortalecer la transparencia, la rendición de cuentas y la inclusión de la ciudadanía en la toma de decisiones. Se promueve un gobierno abierto, eficiente y cercano a la gente.
-                        </p>
-                    </div>
-                )}
-            </div>
+      )}
+      <div className="container mx-auto px-4 text-center py-8 md:py-10">
+        <div className="text-center mb-2">
+            <h2 className="text-4xl md:text-5xl font-bold text-title mb-4">{title_1}</h2>
         </div>
+
+        <div className="mb-2">
+            {title_2 && <p className="text-xl text-subtitle max-w-3xl mx-auto mb-4">{title_2}</p>}
+            {title_3 && <p className="text-lg text-paragraph max-w-4xl mx-auto">{title_3}</p>}
+        </div>
+         <Chart dataSection={dataSection} />
+      </div>
     </section>
   );
 };
-
 
 export const SectionChart = memo( SectionChartComponent);

--- a/src/components/layout/SectionTable.tsx
+++ b/src/components/layout/SectionTable.tsx
@@ -4,15 +4,20 @@ import { SearchFilters } from '@/components/ui/search-filters';
 import { Paginator } from '@/components/ui/paginator';
 import { Separator } from '@/components/ui/separator';
 import { buildDefaultColumns } from '@/components/ui/table-columns';
+import { useSettings } from '@/hooks/useSettings';
+import { OptimizedImageDisplay } from '../ui/optimized-image-display';
 
 interface SectionTableProps<T extends TableRowData> {
   title: string;
   description?: string;
   rows: T[];
   pageSize?: number;
+  withIcon?: boolean;
+  withBackground?: boolean;
 }
 
-export const SectionTable = <T extends TableRowData>({ title, description, rows, pageSize = 7 }: SectionTableProps<T>) => {
+export const SectionTable = <T extends TableRowData>({ title, description, rows, pageSize = 7, withIcon = false, withBackground = false }: SectionTableProps<T>) => {
+  const { siteSettings } = useSettings();
   const [filters, setFilters] = useState({ keyword: '', dependency: '', date: '' });
   const [page, setPage] = useState(1);
 
@@ -35,14 +40,23 @@ export const SectionTable = <T extends TableRowData>({ title, description, rows,
   const pageRows = filtered.slice(start, start + pageSize);
 
   const columns = useMemo(() => buildDefaultColumns<T>(), []);
+  const sectionClassName = useMemo(() => {
+    return `${withBackground ? 'bg-gray-100' : ''}`;
+}, [withBackground]);
 
   return (
-    <section className="container mx-auto px-4 py-12">
+    <section className={sectionClassName}>
+      {withIcon && (
+        <div className="flex flex-row gap-4 justify-center items-center pt-8">
+            <OptimizedImageDisplay imagePath={siteSettings?.icon1} alt={title} className="w-20 h-20" />
+        </div>
+      )}
       <div className="mb-6 text-center">
         <h2 className="text-3xl font-bold text-title">{title}</h2>
         {description && <p className="mt-2 text-lg text-subtitle">{description}</p>}
       </div>
-
+{ pageRows?.length > 0 && (
+  <>
       <div className="mb-4">
         <p className="mb-2 text-sm text-paragraph">Filtra como quieres ver la información:</p>
         <SearchFilters
@@ -63,6 +77,8 @@ export const SectionTable = <T extends TableRowData>({ title, description, rows,
       </div>
 
       <Paginator page={page} totalPages={totalPages} onPageChange={setPage} />
+  </>
+      )}
     </section>
   );
 };

--- a/src/components/ui/Chip.tsx
+++ b/src/components/ui/Chip.tsx
@@ -1,13 +1,14 @@
 import { IItemsSectionCards } from "@/types/settings";
+import { memo } from "react";
 
-export const Chip = (
+const ChipComponent = (
   { label, id, isSelected = false, eventClick, section}: 
   { label: string, id?: string, section: IItemsSectionCards, isSelected?: boolean, eventClick?: (section: IItemsSectionCards) => void }) => {
-    const handleSectionClick = (sectionId: string) => {
-        if (!sectionId) return;
-        if(eventClick) {
+    const handleSectionClick = (sectionId?: string) => {
+        if (eventClick) {
           return eventClick(section);
-        } 
+        }
+        if (!sectionId) return;
         const element = document.getElementById(sectionId);
         if (element) {
           const offsetTop = element.offsetTop - 100; // Account for fixed header
@@ -19,8 +20,8 @@ export const Chip = (
     };
 
     return (
-        <div onClick={() => handleSectionClick(id || "")}
-            className={`flex flex-row justify-center items-center px-4 py-1.5 border 
+        <div onClick={() => handleSectionClick(id)}
+            className={`flex flex-row justify-center items-center whitespace-nowrap px-4 py-1.5 border 
             border-gray-300 rounded-3xl text-[#050038] 
             hover:bg-[#FDFCF1] cursor-pointer hover:border-[#FFDFC1] hover:text-[#F08018] 
             transition-colors duration-200 ${isSelected ? 'bg-[#FDFCF1] border-[#FFDFC1] text-[#F08018]' : null}`}>
@@ -28,3 +29,9 @@ export const Chip = (
         </div>
     )
 }
+
+function areEqual(prev: { label: string, id?: string, section: IItemsSectionCards, isSelected?: boolean, eventClick?: (section: IItemsSectionCards) => void }, next: { label: string, id?: string, section: IItemsSectionCards, isSelected?: boolean, eventClick?: (section: IItemsSectionCards) => void }) {
+  return prev.label === next.label && prev.id === next.id && prev.isSelected === next.isSelected && prev.eventClick === next.eventClick;
+}
+
+export const Chip = memo(ChipComponent, areEqual);

--- a/src/components/ui/chart.tsx
+++ b/src/components/ui/chart.tsx
@@ -1,0 +1,348 @@
+import { memo, useMemo, useState, useCallback, useEffect, useRef } from "react";
+import { IItemsSectionCards, IPaccet, ItemPaccet } from "@/types/settings";
+import { Pie, PieChart, ResponsiveContainer } from "recharts";
+import { Separator } from "../ui/separator";
+import greenPower from "@/assets/svg/green-powersvg.svg";
+import { getApiBaseUrl } from "@/config/environment";
+import { Chip } from '../ui/Chip';
+
+
+interface PieLabelProps {
+  cx: number;
+  cy: number;
+  midAngle: number;
+  innerRadius: number;
+  outerRadius: number;
+  payload: IPaccet;
+}
+
+const RADIAN = Math.PI / 180;
+
+interface SectionChartProps {
+    idSection?: number | string;
+    id?: number | string;
+    sectionClassName?: string;
+    dataSection?: IPaccet[];
+}
+
+export const Chart = ({ id, idSection = 'section-chart', sectionClassName = '', dataSection = [] }: SectionChartProps) => {
+    const data = useMemo<IPaccet[]>(() => {
+      const base: IPaccet[] = dataSection?.length > 0 ? dataSection : [
+         
+        { title: 'Eje 3', icon: greenPower, color: '#8689A1', hoverColor: '#77B82E', value: 20, id: 2, items: [], description1: '', description2: '', order: 3 },
+        { title: 'Eje 2', icon: greenPower, color: '#D0B787', hoverColor: '#77B82E', value: 20, id: 1, items: [], description1: '', description2: '', order: 2 },
+        { title: 'Eje 1', icon: greenPower, color: '#D0B787', hoverColor: '#77B82E', value: 20, id: 1, items: [
+          {
+            "id": 10,
+            "title": "Medida 6",
+            "description": "lorem ipsumm",
+            "order": 6,
+            "paccet": 5
+          },
+          {
+            "id": 9,
+            "title": "Medida 5",
+            "description": "lorem ipsumm",
+            "order": 5,
+            "paccet": 5
+          },
+          {
+            "id": 8,
+            "title": "Medida 4",
+            "description": "Lorem ipsum, dolor sit amet consectetur adipisicing elit. Itaque, ab temporibus aliquam tenetur maxime magnam, quibusdam labore tempore similique dignissimos sunt dolore totam aliquid vel velit voluptate incidunt sit laboriosam.",
+            "order": 4,
+            "paccet": 5
+          },
+          {
+            "id": 7,
+            "title": "Medida 3",
+            "description": "Lorem ipsum dolor sit amet consectetur adipisicing elit. Sunt dolor nemo quo veritatis vitae officia exercitationem. Quis quisquam ratione totam at delectus deserunt quaerat et, debitis veritatis quas consequuntur! Quam?",
+            "order": 3,
+            "paccet": 5
+          },
+          {
+            "id": 6,
+            "title": "Medida 2",
+            "description": "Lorem, ipsum dolor sit amet consectetur adipisicing elit. Ad a, expedita saepe soluta vitae quidem nostrum, necessitatibus optio omnis molestiae repellendus culpa laudantium sint ipsum? Recusandae deserunt expedita sapiente ipsa.",
+            "order": 2,
+            "paccet": 5
+          },
+          {
+            "id": 5,
+            "title": "Medida 1.1",
+            "description": "Lorem ipsum dolor sit amet consectetur adipisicing elit. Dolore ab, dolorem vero vel nesciunt omnis odio nostrum architecto asperiores repudiandae ipsa animi blanditiis enim quisquam doloremque eaque facere? Sapiente, beatae.",
+            "order": 1,
+            "paccet": 5
+          },
+          {
+            "id": 4,
+            "title": "Medida 1",
+            "description": "Lorem ipsum dolor sit amet consectetur adipisicing elit. Saepe, vitae sed obcaecati delectus perferendis amet distinctio maiores sint ipsam, impedit fuga, recusandae laboriosam quo? Quasi dolorem unde minima quod quos!",
+            "order": 0,
+            "paccet": 5
+          },
+          {
+            "id": 11,
+            "title": "Medida 7",
+            "description": "lorem ipsumm",
+            "order": 7,
+            "paccet": 5
+          },
+          {
+            "id": 12,
+            "title": "Medida 8",
+            "description": "lorem ipsum dolor",
+            "order": 8,
+            "paccet": 5
+          },
+          {
+            "id": 13,
+            "title": "Medida 9",
+            "description": "Text 2",
+            "order": 9,
+            "paccet": 5
+          },
+    ], 
+    description1: 'Regulación, control y reducción como criterios de mitigación de emisiones de gases y compuestos de efecto invernadero en el Estado de Tlaxcala', 
+    description2: 'Fortalecer la transparencia, la rendición de cuentas y la inclusión de la ciudadanía en la toma de decisiones. Se promueve un gobierno abierto, eficiente y cercano a la gente.', 
+    order: 1 },
+   
+        { title: 'Eje 7', icon: greenPower, color: '#D0B787', hoverColor: '#77B82E', value: 20, id: 7, items: [], description1: '', description2: '', order: 7 },
+        { title: 'Eje 6', icon: greenPower, color: '#8689A1', hoverColor: '#77B82E', value: 20, id: 6, items: [], description1: '', description2: '', order: 6 },
+        { title: 'Eje 5', icon: greenPower, color: '#D0B787', hoverColor: '#77B82E', value: 20, id: 5, items: [], description1: '', description2: '', order: 5 },
+        { title: 'Eje 4', icon: greenPower, color: '#8689A1', hoverColor: '#77B82E', value: 20, id: 4, items: [], description1: '', description2: '', order: 4 },
+      ];
+
+      const mapped = base.map((item) => ({
+        ...item,
+        icon: `${getApiBaseUrl()}${item.icon}` || greenPower,
+        color: item.color || '#D0B787',
+        hoverColor: item.hoverColor || '#77B82E',
+        value: item.value || 20,
+        items: (item.items || []).slice().sort((a, b) => (a.order ?? 0) - (b.order ?? 0)),
+      }));
+
+      // Custom arrangement (0-based orders in API):
+      // - index 2 -> order 0
+      // - index 1 -> order 1
+      // - index 0 -> order 2
+      // - last index -> order 3
+      // - remaining orders (>=4) placed ascending while filling indices from right to left
+
+      const pool = mapped
+        .slice()
+        .sort((a, b) => (a.order ?? Number.MAX_SAFE_INTEGER) - (b.order ?? Number.MAX_SAFE_INTEGER));
+
+      const takeByOrder = (ord: number) => {
+        const idx = pool.findIndex((it) => (it.order ?? -1) === ord);
+        if (idx >= 0) {
+          const [it] = pool.splice(idx, 1);
+          return it;
+        }
+        return undefined;
+      };
+
+      const result: IPaccet[] = new Array(mapped.length);
+      if (result.length >= 3) result[2] = takeByOrder(0) as IPaccet | undefined as IPaccet;
+      if (result.length >= 2) result[1] = takeByOrder(1) as IPaccet | undefined as IPaccet;
+      if (result.length >= 1) result[0] = takeByOrder(2) as IPaccet | undefined as IPaccet;
+      if (result.length >= 1) result[result.length - 1] = takeByOrder(3) as IPaccet | undefined as IPaccet;
+
+      // Fill remaining slots from right to left with ascending orders (>=4)
+      let writeIdx = result.length - 2; // start before last
+      for (const it of pool) {
+        // find the next empty slot moving leftwards, but skip indices < 3 reserved area
+        while (writeIdx >= 3 && result[writeIdx] !== undefined) {
+          writeIdx--;
+        }
+        if (writeIdx >= 3) {
+          result[writeIdx] = it;
+          writeIdx--;
+        } else {
+          // If there are still empty slots in 0..2 due to missing orders, fill them left-to-right
+          const fallbackIdx = result.findIndex((v) => v === undefined);
+          if (fallbackIdx !== -1) {
+            result[fallbackIdx] = it;
+          } else {
+            // As a last resort (shouldn't happen), push to the end
+            result.push(it);
+          }
+        }
+      }
+
+      return result.filter((v) => v !== undefined);
+    }, [dataSection]);
+  
+    const [hoveredIndex, setHoveredIndex] = useState<number | null>(null);
+    const [selectedIndex, setSelectedIndex] = useState<number | null>(2);
+    const [selectedChips, setSelectedChips] = useState<ItemPaccet[] | []>([]);
+    const [selectedChip, setSelectedChip] = useState<ItemPaccet | null>(null);
+    const chipsContainerRef = useRef<HTMLDivElement | null>(null);
+    const [canScrollLeft, setCanScrollLeft] = useState(false);
+    const [canScrollRight, setCanScrollRight] = useState(false);
+  
+    const handleChipClick = useCallback((chip: ItemPaccet) => {
+      setSelectedChip(chip);
+    }, []);
+    useEffect(() => {
+      if (selectedIndex !== null) {
+        setSelectedChips(data[selectedIndex].items?.sort((a, b) => a.order - b.order));
+        setSelectedChip(data[selectedIndex].items?.[0] || null);
+      }
+    }, [selectedIndex, data]);
+  
+    const chartData = useMemo(() => {
+      return data.map((item, index) => ({
+        ...item,
+        fill:
+          index === selectedIndex || index === hoveredIndex
+            ? item.hoverColor
+            : item.color,
+      }));
+    }, [data, hoveredIndex, selectedIndex]);
+  
+    const handleMouseEnter = useCallback((_: unknown, index: number) => {
+      setHoveredIndex(index);
+    }, []);
+  
+    const handleMouseLeave = useCallback(() => {
+      setHoveredIndex(null);
+    }, []);
+  
+    const handleClick = useCallback((_: unknown, index: number) => {
+      setSelectedIndex(index);
+    }, []);
+  
+    const scrollChips = useCallback((direction: 'left' | 'right') => {
+      const container = chipsContainerRef.current;
+      if (!container) return;
+      const scrollAmount = Math.max(container.clientWidth * 0.6, 240);
+      container.scrollBy({ left: direction === 'left' ? -scrollAmount : scrollAmount, behavior: 'smooth' });
+    }, []);
+  
+    const updateScrollButtons = useCallback(() => {
+      const container = chipsContainerRef.current;
+      if (!container) return;
+      const { scrollLeft, scrollWidth, clientWidth } = container;
+      setCanScrollLeft(scrollLeft > 0);
+      setCanScrollRight(scrollLeft + clientWidth < scrollWidth - 1);
+    }, []);
+  
+    useEffect(() => {
+      updateScrollButtons();
+    }, [selectedChips, updateScrollButtons]);
+  
+    useEffect(() => {
+      const onResize = () => updateScrollButtons();
+      window.addEventListener('resize', onResize);
+      return () => window.removeEventListener('resize', onResize);
+    }, [updateScrollButtons]);
+  
+    const renderSliceLabel = useCallback((props: PieLabelProps) => {
+      const { cx, cy, midAngle, innerRadius, outerRadius, payload } = props;
+      const radius = innerRadius + (outerRadius - innerRadius) * 0.4;
+      const x = cx + radius * Math.cos(-midAngle * RADIAN);
+      const y = cy + radius * Math.sin(-midAngle * RADIAN);
+      const rotation = -midAngle + 90;
+      return (
+        <g transform={`translate(${x},${y}) rotate(${rotation})`} pointerEvents="none" textAnchor="middle">
+          <text dy="12" fill="#FFFFFF" fontSize="12" fontWeight={600}>
+            {payload.title}
+          </text>
+          <image href={payload.icon} width="25" height="25" x={-11} y={-28} />
+        </g>
+      );
+    }, []);
+  
+    return (
+      <section id={idSection?.toString()} className={sectionClassName}>
+          <div className="container mx-auto px-4 text-center py-8 md:py-16">
+              <div id={`section-content-${id}`} className="flex flex-col lg:flex-row justify-center  items-center gap-8 max-w-6xl mx-auto ">
+                  <div className="flex flex-col items-center gap-4 flex-shrink-0">
+                      <div className="relative w-[320px] h-[320px] sm:w-[360px] sm:h-[360px]">
+                          <ResponsiveContainer width="100%" height="100%">
+                              <PieChart>
+                                  <Pie
+                                      data={chartData}
+                                      dataKey="value"
+                                      nameKey="name"
+                                      cx="50%"
+                                      cy="50%"
+                                      innerRadius={85}
+                                      outerRadius={150}
+                                      stroke="#ffffff"
+                                      strokeWidth={1}
+                                      isAnimationActive={false}
+                                      labelLine={false}
+                                      label={renderSliceLabel}
+                                      onMouseEnter={handleMouseEnter}
+                                      onMouseLeave={handleMouseLeave}
+                                      onClick={handleClick}
+                                  />
+                              </PieChart>
+                          </ResponsiveContainer>
+                          <div className="absolute inset-0 flex items-center justify-center pointer-events-none">
+                              <p className="text-center font-bold text-[#F7931E] leading-6 w-44 sm:w-52">
+                                  Da click en
+                                  <br />
+                                  el eje que
+                                  <br />
+                                  quieres consultar
+                              </p>
+                          </div>
+                      </div>
+                  </div>
+                  {typeof selectedIndex === 'number' && (
+                      <div className="flex flex-col justify-start items-start gap-6 text-left flex-1 max-w-2xl">
+                        <h3 className="text-2xl font-bold text-[#77BB2A] max-w-[705px] w-full leading-8">
+                          {data[selectedIndex].title}
+                        </h3>
+                        <h4 className="text-xl font-bold text-[#572772] max-w-[705px] w-full leading-8">
+                          {data[selectedIndex].description1}
+                        </h4>
+                        <Separator />
+                        <div className="w-full relative">
+                          { canScrollLeft && <button
+                            type="button"
+                            aria-label="Desplazar izquierda"
+                            onClick={() => scrollChips('left')}
+                            className={`${canScrollLeft ? '' : 'hidden'} absolute left-0 top-1/2 -translate-y-1/2 z-10 h-7 w-7 rounded-full border bg-white/80 text-[#572772] hover:bg-[#FDFCF1] flex items-center justify-center`}
+                          >
+                            ‹
+                          </button>}
+                          <div
+                            ref={chipsContainerRef}
+                            className={`flex flex-row flex-nowrap items-center gap-4 overflow-x-auto no-scrollbar scroll-smooth ${canScrollLeft || canScrollRight ? 'px-9' : ''}`}
+                            onScroll={updateScrollButtons}
+                          >
+                            {selectedChips?.map((chip) => (
+                              <Chip
+                                key={chip.id}
+                                label={chip.title}
+                                section={chip as unknown as IItemsSectionCards}
+                                eventClick={handleChipClick as unknown as (section: IItemsSectionCards) => void}
+                                isSelected={chip.id === selectedChip?.id}
+                              />
+                            ))}
+                          </div>
+                          <button
+                            type="button"
+                            aria-label="Desplazar derecha"
+                            onClick={() => scrollChips('right')}
+                            className={`${canScrollRight ? '' : 'hidden'} absolute right-0 top-1/2 -translate-y-1/2 z-10 h-7 w-7 rounded-full border bg-white/80 text-[#572772] hover:bg-[#FDFCF1] flex items-center justify-center`}
+                          >
+                            ›
+                          </button>
+                        </div>
+                        <p className="font-light text-base leading-[29px] text-paragraph whitespace-pre-line">
+                          {selectedChip?.description}
+                        </p>
+                      </div>
+                  )}
+              </div>
+          </div>
+      </section>
+    );
+};
+
+export const SectionChart = memo( Chart);

--- a/src/components/ui/table.tsx
+++ b/src/components/ui/table.tsx
@@ -43,7 +43,7 @@ export function Table<T extends TableRowData>({ columns, data, emptyMessage = 'S
           {data.map((row, idx) => (
             <tr key={idx} className="border-t border-gray-100 align-top">
               {columns.map((c) => (
-                <td key={c.key} className={`px-4 py-4 text-sm ${c.className || ''}`}>
+                <td key={c.key} className={`px-4 py-4 text-sm text-paragraph ${c.className || ''}`}>
                   {c.render ? c.render(row) : (row as Record<string, unknown>)[c.key] as React.ReactNode}
                 </td>
               ))}

--- a/src/config/api.ts
+++ b/src/config/api.ts
@@ -21,6 +21,7 @@ class APIConfig {
     SITE_SETTINGS: '/site-settings/',
     CLIMATE_GOVERNANCE_PAGE: '/climate_governance/',
     CLIMATE_INFORMATION_PAGE: '/climate_information/',
+    CLIMATE_AGENDA_PAGE: '/climate_agenda/',
     SUBSCRIBE_TO_NEWSLETTER: '/subscribe/',
   } as const;
 

--- a/src/contexts/SettingsContext.ts
+++ b/src/contexts/SettingsContext.ts
@@ -1,17 +1,19 @@
 import { createContext } from 'react';
-import { ISiteSettingsData, IHomePageData, IClimateGovernancePageData, IClimateInformationPageData } from '@/types/settings';
+import { ISiteSettingsData, IHomePageData, IClimateGovernancePageData, IClimateInformationPageData, IClimateAgendaPageData } from '@/types/settings';
 
 interface SettingsContextType {
   siteSettings: ISiteSettingsData | null;
   homePageData: IHomePageData | null;
   climateGovernancePageData: IClimateGovernancePageData | null;
   climateInformationPageData: IClimateInformationPageData | null;
+  climateAgendaPageData: IClimateAgendaPageData | null;
   isLoading: boolean;
   error: string | null;
   refreshSettings: () => Promise<void>;
   refreshHomePage: () => Promise<void>;
   refreshClimateGovernancePage: () => Promise<void>;
   refreshClimateInformationPage: () => Promise<void>;
+  refreshClimateAgendaPage: () => Promise<void>;
   // Global loading state
   globalLoading: boolean;
   setGlobalLoading: (loading: boolean) => void;

--- a/src/hooks/index.ts
+++ b/src/hooks/index.ts
@@ -4,6 +4,7 @@ export { useSettingsContext } from './useSettingsContext';
 export { useHomePage } from './useHomePage';
 export { useClimateGovernance } from './useClimateGovernance';
 export { useClimateInformation } from './useClimateInformation';
+export { useClimateAgenda } from './useClimateAgenda';
 export { useImageUrl } from './useImageUrl';
 export { useOptimizedImageUrl } from './useOptimizedImageUrl';
 

--- a/src/hooks/settings.ts
+++ b/src/hooks/settings.ts
@@ -1,5 +1,5 @@
 import { useQuery } from '@tanstack/react-query';
-import { IClimateGovernancePageData, IClimateInformationPageData, IHomePageData, ISiteSettingsData } from "@/types/settings";
+import { IClimateAgendaPageData, IClimateGovernancePageData, IClimateInformationPageData, IHomePageData, ISiteSettingsData } from "@/types/settings";
 import APIService from "../services/apiService";
 
 interface NewsletterSubscriptionResponse {
@@ -17,6 +17,7 @@ const queryKeys = {
   siteSettings: ['siteSettings'] as const,
   climateGovernancePage: ['climateGovernancePage'] as const,
   climateInformationPage: ['climateInformationPage'] as const,
+  climateAgendaPage: ['climateAgendaPage'] as const,
 } as const;
 
 // API functions
@@ -43,6 +44,15 @@ const fetchClimateInformationPage = async (): Promise<IClimateInformationPageDat
     return await apiService.get<IClimateInformationPageData>(apiConfig.ENDPOINTS.CLIMATE_INFORMATION_PAGE) as unknown as IClimateInformationPageData;
   } catch (error) {
     console.error('Error fetching climate information page:', error);
+    throw error;
+  }
+};
+
+const fetchClimateAgendaPage = async (): Promise<IClimateAgendaPageData> => {
+  try {
+    return await apiService.get<IClimateAgendaPageData>(apiConfig.ENDPOINTS.CLIMATE_AGENDA_PAGE) as unknown as IClimateAgendaPageData;
+  } catch (error) {
+    console.error('Error fetching climate agenda page:', error);
     throw error;
   }
 };
@@ -101,6 +111,18 @@ const useSettings = () => {
     retry: 2,
   });
 
+  // Climate agenda page query
+
+  const climateAgendaPageQuery = useQuery<IClimateAgendaPageData>({
+    queryKey: queryKeys.climateAgendaPage,
+    queryFn: fetchClimateAgendaPage,
+    staleTime: 10 * 60 * 1000, // 10 minutes
+    gcTime: 20 * 60 * 1000, // 20 minutes (garbage collection time)
+    refetchOnWindowFocus: false,
+    refetchOnMount: false,
+    retry: 2,
+  });
+
   const subscribeToNewsletter = async (email: string): Promise<NewsletterSubscriptionResponse> => {
     try {
       const response = await apiService.post<NewsletterSubscriptionResponse>(
@@ -121,6 +143,12 @@ const useSettings = () => {
     homePageError: homePageQuery.error,
     refreshHomePage: homePageQuery.refetch,
 
+    // Climate agenda page data
+    climateAgendaPageData: climateAgendaPageQuery.data || null,
+    climateAgendaPageIsLoading: climateAgendaPageQuery.isLoading,
+    climateAgendaPageError: climateAgendaPageQuery.error,
+    refreshClimateAgendaPage: climateAgendaPageQuery.refetch,
+
     // Climate governance page data
     climateGovernancePageData: climateGovernancePageQuery.data || null,
     climateGovernancePageIsLoading: climateGovernancePageQuery.isLoading,
@@ -140,10 +168,10 @@ const useSettings = () => {
     refreshSiteSettings: siteSettingsQuery.refetch,
     
     // Combined loading state
-    isLoading: homePageQuery.isLoading || siteSettingsQuery.isLoading || climateGovernancePageQuery.isLoading || climateInformationPageQuery.isLoading,
+    isLoading: homePageQuery.isLoading || siteSettingsQuery.isLoading || climateGovernancePageQuery.isLoading || climateInformationPageQuery.isLoading || climateAgendaPageQuery.isLoading,
     
     // Combined error state
-    error: homePageQuery.error || siteSettingsQuery.error || climateGovernancePageQuery.error || climateInformationPageQuery.error,
+    error: homePageQuery.error || siteSettingsQuery.error || climateGovernancePageQuery.error || climateInformationPageQuery.error || climateAgendaPageQuery.error,
     
     // Newsletter subscription
     subscribeToNewsletter,

--- a/src/hooks/useClimateAgenda.ts
+++ b/src/hooks/useClimateAgenda.ts
@@ -1,0 +1,30 @@
+import { useMemo } from "react";
+import { useSettings } from "./useSettings";
+
+export const useClimateAgenda = () => {
+  const { climateAgendaPageData, isLoading, error, refreshClimateAgendaPage } = useSettings();
+
+  // Memoized header data with proper dependency
+  const headerData = useMemo(() => {
+    if (!climateAgendaPageData?.header?.[0]) return null;
+    return climateAgendaPageData.header[0];
+  }, [climateAgendaPageData?.header]);
+
+  // Memoized sections data with proper dependencies
+  const firstSection = useMemo(() => climateAgendaPageData?.first_section, [climateAgendaPageData?.first_section]);
+  const secondSection = useMemo(() => climateAgendaPageData?.second_section, [climateAgendaPageData?.second_section]);
+  const thirdSection = useMemo(() => climateAgendaPageData?.third_section, [climateAgendaPageData?.third_section]);
+  const paccet = useMemo(() => climateAgendaPageData?.paccet, [climateAgendaPageData?.paccet]);
+
+  return {
+    climateAgendaPageData,
+    isLoading,
+    error,
+    refreshClimateAgendaPage,
+    headerData,
+    firstSection,
+    secondSection,
+    thirdSection,
+    paccet,
+  };
+};

--- a/src/hooks/useSettings.ts
+++ b/src/hooks/useSettings.ts
@@ -9,6 +9,7 @@ export const useSettings = () => {
   const homePageData = useMemo(() => context.homePageData, [context.homePageData]);
   const climateGovernancePageData = useMemo(() => context.climateGovernancePageData, [context.climateGovernancePageData]);
   const climateInformationPageData = useMemo(() => context.climateInformationPageData, [context.climateInformationPageData]);
+  const climateAgendaPageData = useMemo(() => context.climateAgendaPageData, [context.climateAgendaPageData]);
   const isLoading = useMemo(() => context.isLoading, [context.isLoading]);
   const error = useMemo(() => context.error, [context.error]);
 
@@ -17,11 +18,13 @@ export const useSettings = () => {
   const refreshHomePage = useCallback(() => context.refreshHomePage(), [context.refreshHomePage]);
   const refreshClimateGovernancePage = useCallback(() => context.refreshClimateGovernancePage(), [context.refreshClimateGovernancePage]);
   const refreshClimateInformationPage = useCallback(() => context.refreshClimateInformationPage(), [context.refreshClimateInformationPage]);
+  const refreshClimateAgendaPage = useCallback(() => context.refreshClimateAgendaPage(), [context.refreshClimateAgendaPage]);
   // Memoized computed values
   const hasSettings = useMemo(() => Boolean(siteSettings), [siteSettings]);
   const hasHomePageData = useMemo(() => Boolean(homePageData), [homePageData]);
   const hasClimateGovernancePageData = useMemo(() => Boolean(climateGovernancePageData), [climateGovernancePageData]);
   const hasClimateInformationPageData = useMemo(() => Boolean(climateInformationPageData), [climateInformationPageData]);
+  const hasClimateAgendaPageData = useMemo(() => Boolean(climateAgendaPageData), [climateAgendaPageData]);
   // Memoized specific settings getters
   const getHeaderLogo = useCallback((useElectoralBan: boolean = false): string => {
     if (!siteSettings) return '';
@@ -67,6 +70,7 @@ export const useSettings = () => {
     homePageData,
     climateGovernancePageData,
     climateInformationPageData,
+    climateAgendaPageData,
     isLoading,
     error,
     
@@ -75,11 +79,13 @@ export const useSettings = () => {
     hasHomePageData,
     hasClimateGovernancePageData,
     hasClimateInformationPageData,
+    hasClimateAgendaPageData,
     // Actions
     refreshSettings,
     refreshHomePage,
     refreshClimateGovernancePage,
     refreshClimateInformationPage,
+    refreshClimateAgendaPage,
     // Specific getters
     getHeaderLogo,
     getFooterLogo,

--- a/src/index.css
+++ b/src/index.css
@@ -156,6 +156,25 @@
   }
 }
 
+/* Recharts: remove focus outline on clicked slices */
+.recharts-wrapper {
+  -webkit-tap-highlight-color: transparent;
+}
+
+.recharts-wrapper *:focus {
+  outline: none !important;
+}
+
+/* Utility: hide scrollbars but keep scroll functionality */
+.no-scrollbar {
+  -ms-overflow-style: none; /* IE and Edge */
+  scrollbar-width: none; /* Firefox */
+}
+
+.no-scrollbar::-webkit-scrollbar {
+  display: none; /* Chrome, Safari */
+}
+
 /* Custom typography utilities */
 @layer utilities {
   .text-heading {

--- a/src/pages/ClimateAgendaPage.tsx
+++ b/src/pages/ClimateAgendaPage.tsx
@@ -1,32 +1,26 @@
+import Hero from "@/components/layout/Hero";
 import { SectionChart } from "@/components/layout/SectionChart";
+import { SectionChips } from "@/components/layout/SectionChips";
 import SectionTable from "@/components/layout/SectionTable";
-import { StatusKind } from "@/components/ui/status-badge";
+import { useClimateAgenda } from "@/hooks";
 
 const ClimateAgendaPage = () => {
 
+  const { headerData, firstSection, secondSection, thirdSection, paccet } = useClimateAgenda();
+
   return (
     <div className="min-h-screen bg-gray-50">
-
-
-        <SectionChart />
+      <Hero headerData={headerData} />
+        <SectionChart {...firstSection} dataSection={paccet} withIcon={true} />
         <SectionTable
-          title="Avances en el PACCET"
-          description="Conoce las acciones que contribuyen a las metas del Programa de acción ante el cambio climático del estado de Tlaxcala"
+          title={secondSection?.title_1 || ''}
+          description={secondSection?.title_2 || ''}
+          withIcon={true}
+          withBackground={true}
           rows={[
-            {
-              avance:
-                "Presenta un alto riesgo debido a la caída de bloques por fracturamiento, lo que afecta la infraestructura, especialmente los caminos, aunque no impacta directamente bienes.",
-              fecha: "2025-03-04",
-              aporte: [
-                { label: "Eje 1", info: { title: "Eje 1", description: "Regulación, control y reducción...", href: "#" } },
-                { label: "Eje 2", info: { title: "Eje 2", description: "Regulación, control y reducción...", href: "#" } },
-                { label: "Eje 3", info: { title: "Eje 3", description: "Regulación, control y reducción...", href: "#" } },
-              ],
-              medida: "Caída de bloques",
-              status: "EN_PROCESO" as StatusKind,
-            },
           ]}
         />
+        <SectionChips {...thirdSection} withIcon={true} />
 
     </div>
   );

--- a/src/providers/SettingsProvider.tsx
+++ b/src/providers/SettingsProvider.tsx
@@ -18,23 +18,25 @@ export const SettingsProvider: React.FC<SettingsProviderProps> = ({ children }) 
     siteSettings,
     climateGovernancePageData,
     climateInformationPageData,
+    climateAgendaPageData,
     isLoading,
     error,
     refreshHomePage,
     refreshSiteSettings,
     refreshClimateGovernancePage,
     refreshClimateInformationPage,
+    refreshClimateAgendaPage,
   } = useSettings();
 
-  const { setSettings, setHomePage, setClimateGovernancePageData, setClimateInformationPageData } = useSettingsStore();
+  const { setSettings, setHomePage, setClimateGovernancePageData, setClimateInformationPageData, setClimateAgendaPageData } = useSettingsStore();
 
   // Inicializar el estado de loading cuando la app se carga
   React.useEffect(() => {
     // Si tenemos datos cargados, ocultar el loading inicial
-    if (siteSettings || homePageData || climateGovernancePageData || climateInformationPageData) {
+    if (siteSettings || homePageData || climateGovernancePageData || climateInformationPageData || climateAgendaPageData) {
       setGlobalLoading(false);
     }
-  }, [siteSettings, homePageData, climateGovernancePageData, climateInformationPageData]);
+  }, [siteSettings, homePageData, climateGovernancePageData, climateInformationPageData, climateAgendaPageData  ]);
 
   // Registrar el contexto de loading para APIService
   React.useEffect(() => {
@@ -65,6 +67,12 @@ export const SettingsProvider: React.FC<SettingsProviderProps> = ({ children }) 
       setClimateInformationPageData(climateInformationPageData);
     }
   }, [climateInformationPageData, setClimateInformationPageData]);
+
+  React.useEffect(() => {
+    if (climateAgendaPageData) {
+      setClimateAgendaPageData(climateAgendaPageData);
+    }
+  }, [climateAgendaPageData, setClimateAgendaPageData]);
 
   // Wrapper functions to match expected types
   const handleRefreshSettings = useCallback(async () => {
@@ -99,21 +107,31 @@ export const SettingsProvider: React.FC<SettingsProviderProps> = ({ children }) 
     }
   }, [refreshClimateInformationPage]);
 
+  const handleRefreshClimateAgendaPage = useCallback(async () => {
+    try {
+      await refreshClimateAgendaPage();
+    } catch (error) {
+      console.error('Error refreshing climate agenda page:', error);
+    }
+  }, [refreshClimateAgendaPage]);
+
   // Memoized context value to prevent unnecessary re-renders
   const contextValue = useMemo(() => ({
     siteSettings,
     homePageData,
     climateGovernancePageData,
     climateInformationPageData,
+    climateAgendaPageData,
     isLoading,
     error: error?.message || null,
     refreshSettings: handleRefreshSettings,
     refreshHomePage: handleRefreshHomePage,
     refreshClimateGovernancePage: handleRefreshClimateGovernancePage,
     refreshClimateInformationPage: handleRefreshClimateInformationPage,
+    refreshClimateAgendaPage: handleRefreshClimateAgendaPage,
     globalLoading,
     setGlobalLoading,
-  }), [siteSettings, homePageData, climateGovernancePageData, climateInformationPageData, isLoading, error, handleRefreshSettings, handleRefreshHomePage, handleRefreshClimateGovernancePage, handleRefreshClimateInformationPage, globalLoading, setGlobalLoading]);
+  }), [siteSettings, homePageData, climateGovernancePageData, climateInformationPageData, climateAgendaPageData, isLoading, error, handleRefreshSettings, handleRefreshHomePage, handleRefreshClimateGovernancePage, handleRefreshClimateInformationPage, handleRefreshClimateAgendaPage, globalLoading, setGlobalLoading]);
 
   return (
     <SettingsContext.Provider value={contextValue}>

--- a/src/routes/AppRoutes.tsx
+++ b/src/routes/AppRoutes.tsx
@@ -6,8 +6,8 @@ const HomePage = lazy(() => import('@/pages/HomePage'));
 const ClimateGovernancePage = lazy(() => import('@/pages/ClimateGovernancePage'));
 const ClimateInformationPage = lazy(() => import('@/pages/ClimateInformation'));
 const NotFoundPage = lazy(() => import('@/pages/NotFoundPage'));
-// const ClimateAgendaPage = lazy(() => import('@/pages/ClimateAgendaPage'));
-// const NewsPage = lazy(() => import('@/pages/NewsPage'));
+const ClimateAgendaPage = lazy(() => import('@/pages/ClimateAgendaPage'));
+const NewsPage = lazy(() => import('@/pages/NewsPage'));
 
 const AppRoutes = () => {
     return (
@@ -16,8 +16,8 @@ const AppRoutes = () => {
             <Route path="/" element={<HomePage />} />
             <Route path="/climate-governance" element={<ClimateGovernancePage />} />
             <Route path="/climate-information" element={<ClimateInformationPage />} />
-            {/* <Route path="/climate-agenda" element={<ClimateAgendaPage />} />
-            <Route path="/news" element={<NewsPage />} /> */}
+            <Route path="/climate-agenda" element={<ClimateAgendaPage />} />
+            <Route path="/news" element={<NewsPage />} />
             {/* Fallbacks */}
             <Route path="/404" element={<NotFoundPage />} />
             <Route path="*" element={<Navigate to="/404" replace />} />

--- a/src/stores/useSettings.ts
+++ b/src/stores/useSettings.ts
@@ -1,6 +1,6 @@
 import { create } from "zustand";
 import { combine, devtools } from "zustand/middleware";
-import { IClimateGovernancePageData, IClimateInformationPageData, IHomePageData, ISiteSettingsData } from "@/types/settings";
+import { IClimateAgendaPageData, IClimateGovernancePageData, IClimateInformationPageData, IHomePageData, ISiteSettingsData } from "@/types/settings";
 
 export const SettingsInitialState: ISiteSettingsData = {
 	id: 0,
@@ -199,13 +199,33 @@ export const ClimateInformationPageInitialState: IClimateInformationPageData = {
 		button_text2: "",
 	},
 };
+
+export const ClimateAgendaPageInitialState: IClimateAgendaPageData = {
+	header: [],
+	first_section: {
+		id: 0,
+		items: [],
+		section: "",
+		title_1: "",
+		title_2: "",
+		title_3: "",
+		boton_texto: "",
+		button_text: "",
+		button_action_url: "",
+		button1_action_url: "",
+		button_text1: "",
+		button2_action_url: "",
+		button_text2: "",
+	},
+};
 export const useSettingsStore = create(
 	devtools(
-        combine([SettingsInitialState, HomePageInitialState, ClimateGovernancePageInitialState, ClimateInformationPageInitialState], (set, get) => ({
+        combine([SettingsInitialState, HomePageInitialState, ClimateGovernancePageInitialState, ClimateInformationPageInitialState, ClimateAgendaPageInitialState], (set, get) => ({
             setSettings: (settings: ISiteSettingsData) => set([settings, get()[1]]),
 			setHomePage: (homePage: IHomePageData) => set([get()[0], homePage]),
 			setClimateGovernancePageData: (climateGovernancePageData: IClimateGovernancePageData) => set([get()[0], get()[1], climateGovernancePageData]),
 			setClimateInformationPageData: (climateInformationPageData: IClimateInformationPageData) => set([get()[0], get()[1], get()[2], climateInformationPageData]),
+			setClimateAgendaPageData: (climateAgendaPageData: IClimateAgendaPageData) => set([get()[0], get()[1], get()[2], get()[3], climateAgendaPageData]),
         }))
 	)
 );  

--- a/src/types/settings.ts
+++ b/src/types/settings.ts
@@ -21,6 +21,14 @@ export interface IClimateInformationPageData {
   fourth_section: ISectionCards;
 }
 
+export interface IClimateAgendaPageData {
+  header: Array<IHeader>;
+  first_section?: ISectionCards;
+  second_section?: ISectionCards;
+  third_section?: ISectionCards;
+  paccet?: IPaccet[];
+}
+
 export interface ISiteSettingsData {
   id:                            number;
   header_logo:                   string;
@@ -83,4 +91,25 @@ export interface IHeader {
   button_action_url: string;
   video_internal: string | null;
   image_internal: string;
+}
+
+export interface IPaccet {
+  id:           number;
+  items:        ItemPaccet[];
+  title:        string;
+  description1: string;
+  description2: string;
+  icon:         string;
+  color:        string;
+  order:        number;
+  hoverColor?:   string;
+  value?:        number;
+}
+
+export interface ItemPaccet {
+  id:          number;
+  title:       string;
+  description: string;
+  order:       number;
+  paccet:      number;
 }


### PR DESCRIPTION
- Implementa <Chart> con orden personalizado de dataSection (idx2←order0, idx1←order1, idx0←order2, último←order3; resto ascendente rellenando de derecha a izquierda).

- Contenedor de chips con scroll horizontal sin barra visible y botones condicionales (solo cuando hay overflow).

- Memoización de Chip y callbacks estables para reducir re-renders (mejora de performance).

- Alineación de textos a la izquierda y refinamientos visuales.

- Se añade utilitario .no-scrollbar y se quita outline de focus en Recharts.

refactor(section-chart): usar <Chart> y simplificar props.

chore(agenda): agrega hook useClimateAgenda y actualiza ClimateAgendaPage/rutas.

touch: ajustes menores en SectionTable, table.tsx, settings y provider.